### PR TITLE
Split hand

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,12 +20,18 @@
 
         <h3>Your cards</h3>
         <div id="player-cards"></div>
+
+        <div id="split-display" style="display: none">
+            <h3>Split cards</h3>
+            <div id="split-cards"></div>
+        </div>
     </div>
 
     <div id="controls-display">
         <div id="controls" style="display: none;">
             <button onclick="hit()">hit</button>
-            <button onclick="endRound()">stay</button>
+            <button onclick="stay()">stay</button>
+            <button id="split-btn" onclick="split()">split</button>
         </div>
         <div id="bet-entry" style="display: none;">
             <button onclick="decreaseBet()">-</button>&nbsp;
@@ -37,37 +43,7 @@
         </div>
         <h3 id="point-display"></h3>
         <h2 id="round-results" style="color: red; display: none;">a</h2>
-    </div>
-
-    <!-- <table id="layout">
-        <tr>
-            <td>
-                <h3>Dealer's cards</h3>
-                <div id="dealer-cards"></div> 
-
-                <h3>Your cards</h3>
-                <div id="player-cards"></div>
-            </td>
-            <td>
-                <div id="controls" style="display: none;">
-                    <button onclick="hit()">hit</button>
-                    <button onclick="endRound()">stay</button>
-                </div>
-                <div id="bet-entry" style="display: none;">
-                    <button onclick="decreaseBet()">-</button>&nbsp;
-                    <span id="bet-display">10</span>&nbsp;
-                    <button onclick="increaseBet()">+</button>
-                    <br />
-                    <br />
-                    <button onclick="placeBet()">Place bet</button>
-                </div>
-                <h3 id="point-display"></h3>
-                <h2 id="round-results" style="color: red; display: none;">a</h2>
-            </td>
-        </tr>
-    </table> -->
-
-    
+    </div>    
 
     <script src="src/card.js"></script>
     <script src="src/deck.js"></script>

--- a/index.html
+++ b/index.html
@@ -28,10 +28,11 @@
     </div>
 
     <div id="controls-display">
+        <h3 id="active-hand-display" style="color: red; display: none;"></h3>
         <div id="controls" style="display: none;">
             <button onclick="hit()">hit</button>
             <button onclick="stay()">stay</button>
-            <button id="split-btn" onclick="split()">split</button>
+            <button id="split-btn" onclick="split()" style="visibility: hidden;">split</button>
         </div>
         <div id="bet-entry" style="display: none;">
             <button onclick="decreaseBet()">-</button>&nbsp;

--- a/src/player.js
+++ b/src/player.js
@@ -1,6 +1,7 @@
 class Player {
     constructor(initialPoints=100) {
         this.cards = [];
+        this.splitCards = []; // should only be populated when the player splits
         this.points = initialPoints;
         this.bet = 10; // minimum bet is 10
     }
@@ -9,12 +10,22 @@ class Player {
         this.cards.push(card);
     }
 
+    giveSplitCard = (card) => {
+        this.splitCards.push(card);
+    }
+
     resetCards = () => {
         this.cards = [];
     }
 
-    // calculate the total of the current cards in the players hand
-    getCardTotal = () => {
+    // this assumes the player currently has two cards in their hand
+    // takes one card and moves it to splitCards
+    split = () => {
+        this.splitCards.push(this.cards.pop());
+    }
+
+    // gets the total of a hand given a list of cards
+    getHandCardTotal = (cards) => {
         let total = 0;
 
         // ace is worth 11 if it doesn't make the hand go over 21
@@ -24,7 +35,7 @@ class Player {
         let aces = [];
 
         // make separate lists of non-aces and aces, then combine them with the aces last
-        this.cards.forEach(card => {
+        cards.forEach(card => {
             if(card.rank === 'ace') {
                 aces.push(card);
             }
@@ -49,5 +60,15 @@ class Player {
         });
 
         return total;
+    }
+
+    // calculate the total of the current cards in the players hand
+    getCardTotal = () => {
+        return this.getHandCardTotal(this.cards);
+    }
+
+    // calculate the total of the current cards in the players hand
+    getSplitCardTotal = () => {
+        return this.getHandCardTotal(this.splitCards);
     }
 }


### PR DESCRIPTION
- if a player is dealt two cards with the same rank (i.e. two 6's), they have the option to split
- split button is only visible when the cards are the same rank
- once split, the player will play the first hand until they click 'stay' or until they bust
- they will then play their second hand until they stay or bust
- if they split, round results are as follow:
    - if player won only one of their hands: draw
    - if player won both of their hands: player won
    - if player lost both hands: lose
    - if player ties dealer on both hands: draw
- previously, the dealer would only play their hand if the player didn't bust. Now it needs to take into account whether the player split. The dealer will now play they hand if the player didn't bust on at least one of their hands after splitting.